### PR TITLE
run riak_mnesia job on Erlang/OTP 17.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ env:
         - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
         - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
         - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
-        - PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
         - PRESET=cassandra_mnesia DB=cassandra REL_CONFIG=with-cassandra CASSANDRA_VERSION=3.1
         - PRESET=dialyzer_only
 
@@ -61,7 +60,7 @@ matrix:
         - otp_release: 19.0
           env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG=with-pgsql
         - otp_release: 17.5
-          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none
+          env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
 
 notifications:
     webhooks:


### PR DESCRIPTION
riak_mnesia job doesn't require any specyfic built-in libs.
All is needed here is specified as a dependency and
can be safely build on older but still supported version of Erlang/OTP
