### PR TITLE
Mam refactoring

### DIFF
--- a/apps/ejabberd/src/ejabberd_gen_mam_archive.erl
+++ b/apps/ejabberd/src/ejabberd_gen_mam_archive.erl
@@ -11,17 +11,8 @@
     ok | {error, timeout}.
 
 -callback lookup_messages(Result :: any(), Host :: ejabberd:server(),
-                          ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid(),
-                          RSM :: jlib:rsm_in() | undefined,
-                          Borders :: mod_mam:borders() | undefined,
-                          Start :: mod_mam:unix_timestamp() | undefined,
-                          End :: mod_mam:unix_timestamp() | undefined,
-                          Now :: mod_mam:unix_timestamp(),
-                          WithJID :: ejabberd:jid() | undefined,
-                          SearchText :: binary() | undefined, PageSize :: integer(),
-                          LimitPassed :: boolean() | opt_count, MaxResultLimit :: integer(),
-                          IsSimple :: boolean()) -> {ok, mod_mam:lookup_result()}
-                                                        | {error, 'policy-violation'}.
+                          Params :: map()) -> Result when
+      Result :: {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
 
 -callback remove_archive(Acc :: map(), Host :: ejabberd:server(),
     ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid()) -> map().

--- a/apps/ejabberd/src/mod_commands.erl
+++ b/apps/ejabberd/src/mod_commands.erl
@@ -334,22 +334,15 @@ lookup_recent_messages(ArcJID, With, Before, Limit) when is_binary(With) ->
 lookup_recent_messages(ArcJID, WithJID, Before, Limit) ->
     Host = ArcJID#jid.server,
     ArcID = mod_mam:archive_id(Host, ArcJID#jid.user),
-    Borders = undefined,
     RSM = #rsm_in{direction = before, id = undefined}, % last msgs
-    Start = undefined,
     End = Before * 1000000,
     Now = p1_time_compat:os_system_time(micro_seconds),
-    WithJID = WithJID,
-    SearchText = undefined,
     PageSize = Limit,
-    LimitPassed = false,
-    MaxResultLimit = 1,
-    IsSimple = true,
-    R = ejabberd_hooks:run_fold(mam_lookup_messages, Host, {ok, {0, 0, []}},
-                                [Host, ArcID, ArcJID, RSM, Borders,
-                                 Start, End, Now, WithJID, SearchText,
-                                 PageSize, LimitPassed, MaxResultLimit,
-                                 IsSimple]),
+    R = mod_mam:lookup_messages(Host, ArcID, _ArchiveJID = ArcJID, RSM,
+                                _Borders = undefined, _Start = undefined,
+                                End, Now, WithJID, _SearchText = undefined,
+                                PageSize, _LimitPassed = false,
+                                _MaxResultLimit = 50, _IsSimple = true),
     {ok, {_, _, L}} = R,
     L.
 

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -794,15 +794,26 @@ remove_archive(Host, ArcID, ArcJID=#jid{}) ->
                                  | {error, Reason :: term()}.
 lookup_messages(Host, ArcID, ArcJID, RSM, Borders, Start, End, Now,
                 WithJID, SearchText, PageSize, LimitPassed, MaxResultLimit, IsSimple) ->
-    StartT = os:timestamp(),
     case SearchText /= undefined andalso not mod_mam_utils:has_full_text_search(?MODULE, Host) of
         true -> %% Use of disabled full text search
             {error, 'not-supported'};
         false ->
+            Params = #{archive_id => ArcID,
+                       owner_jid => ArcJID,
+                       with_jid => WithJID,
+                       rsm => RSM,
+                       borders => Borders,
+                       start_ts => Start,
+                       end_ts => End,
+                       now => Now,
+                       search_text => SearchText,
+                       page_size => PageSize,
+                       limit_passed => LimitPassed,
+                       max_result_limit => MaxResultLimit,
+                       is_simple => IsSimple},
+            StartT = os:timestamp(),
             R = ejabberd_hooks:run_fold(mam_lookup_messages, Host, {ok, {0, 0, []}},
-                                        [Host, ArcID, ArcJID, RSM, Borders,
-                                         Start, End, Now, WithJID, SearchText,
-                                         PageSize, LimitPassed, MaxResultLimit, IsSimple]),
+                                        [Host, Params]),
             Diff = timer:now_diff(os:timestamp(), StartT),
             mongoose_metrics:update(Host, [backends, ?MODULE, lookup], Diff),
             R

--- a/apps/ejabberd/src/mod_mam_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_arch.erl
@@ -6,6 +6,7 @@
 %%%-------------------------------------------------------------------
 -module(mod_mam_cassandra_arch).
 -behaviour(mongoose_cassandra).
+-behaviour(ejabberd_gen_mam_archive).
 
 %% ----------------------------------------------------------------------
 %% Exports
@@ -16,7 +17,7 @@
 %% MAM hook handlers
 -export([archive_size/4,
          archive_message/9,
-         lookup_messages/15,
+         lookup_messages/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -275,37 +276,18 @@ message_id_to_remote_jid(PoolName, UserJID, BUserJID, MessID) ->
 %% ----------------------------------------------------------------------
 %% SELECT MESSAGES
 
--spec lookup_messages(Result :: any(), Host :: ejabberd:server(),
-                      ArchiveID :: mod_mam:archive_id(),
-                      ArchiveJID :: ejabberd:jid(),
-                      RSM :: jlib:rsm_in()  | undefined,
-                      Borders :: mod_mam:borders()  | undefined,
-                      Start :: mod_mam:unix_timestamp()  | undefined,
-                      End :: mod_mam:unix_timestamp()  | undefined,
-                      Now :: mod_mam:unix_timestamp(),
-                      WithJID :: ejabberd:jid()  | undefined,
-                      SearchText :: binary() | undefined,
-                      PageSize :: non_neg_integer(), LimitPassed :: boolean(),
-                      MaxResultLimit :: non_neg_integer(),
-                      IsSimple :: boolean()  | opt_count) ->
-                             {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
-lookup_messages({error, _Reason} = Result, _Host,
-                _UserID, _UserJID, _RSM, _Borders,
-                _Start, _End, _Now, _WithJID, _SearchText,
-                _PageSize, _LimitPassed, _MaxResultLimit,
-                _IsSimple) ->
+-spec lookup_messages(Result :: any(), Host :: ejabberd:server(), Params :: map()) ->
+  {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
+lookup_messages({error, _Reason} = Result, _Host, _Params) ->
     Result;
-lookup_messages(_Result, _Host,
-                _UserID, _UserJID, _RSM, _Borders,
-                _Start, _End, _Now, _WithJID, <<_SearchText/binary>>,
-                _PageSize, _LimitPassed, _MaxResultLimit,
-                _IsSimple) ->
+lookup_messages(_Result, _Host, #{search_text := <<_/binary>>}) ->
     {error, 'not-supported'};
 lookup_messages(_Result, Host,
-                _UserID, UserJID, RSM, Borders,
-                Start, End, _Now, WithJID, _SearchText = undefined,
-                PageSize, LimitPassed, MaxResultLimit,
-                IsSimple) ->
+                #{owner_jid := UserJID, rsm := RSM, borders := Borders,
+                  start_ts := Start, end_ts := End, with_jid := WithJID,
+                  search_text := undefined, page_size := PageSize,
+                  limit_passed := LimitPassed, max_result_limit := MaxResultLimit,
+                  is_simple := IsSimple}) ->
     try
         PoolName = pool_name(UserJID),
         lookup_messages2(PoolName, Host,

--- a/apps/ejabberd/src/mod_mam_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_arch.erl
@@ -31,7 +31,10 @@
 %% Other
 -import(mod_mam_utils,
         [maybe_min/2,
-         maybe_max/2]).
+         maybe_max/2,
+         bare_jid/1,
+         full_jid/1
+         ]).
 
 -include_lib("ejabberd/include/ejabberd.hrl").
 -include_lib("ejabberd/include/jlib.hrl").
@@ -491,7 +494,7 @@ rows_to_uniform_format(MessageRows) ->
     [row_to_uniform_format(Row) || Row <- MessageRows].
 
 row_to_uniform_format(#{from_jid := FromJID, message := Msg, id := MsgID}) ->
-    SrcJID = unserialize_jid(FromJID),
+    SrcJID = jid:from_binary(FromJID),
     Packet = stored_binary_to_packet(Msg),
     {MsgID, SrcJID, Packet}.
 
@@ -510,7 +513,7 @@ purge_single_message(_Result, _Host, MessID, _UserID, UserJID, _Now) ->
     Result = message_id_to_remote_jid(PoolName, UserJID, BUserJID, MessID),
     case Result of
         {ok, BRemFullJID} ->
-            RemFullJID = unserialize_jid(BRemFullJID),
+            RemFullJID = jid:from_binary(BRemFullJID),
             RemBareJID = jid:to_bare(RemFullJID),
             BRemBareJID = jid:to_binary(RemBareJID),
             %% Remove duplicates if RemFullJID =:= RemBareJID
@@ -793,19 +796,10 @@ calc_offset(PoolName, UserJID, Host, F, _PS, _TC, #rsm_in{direction = aft, id = 
 calc_offset(_W, _UserJID, _LS, _F, _PS, _TC, _RSM) ->
     0.
 
-bare_jid(undefined) -> undefined;
-bare_jid(JID) ->
-    jid:to_binary(jid:to_bare(jid:to_lower(JID))).
-
-full_jid(JID) ->
-    jid:to_binary(jid:to_lower(JID)).
-
+-spec maybe_full_jid(undefined | ejabberd:jid()) -> undefined | binary().
 maybe_full_jid(undefined) -> <<>>;
 maybe_full_jid(JID) ->
     jid:to_binary(jid:to_lower(JID)).
-
-unserialize_jid(BJID) ->
-    jid:from_binary(BJID).
 
 %%====================================================================
 %% Internal SQL part

--- a/apps/ejabberd/src/mod_mam_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_arch.erl
@@ -28,21 +28,10 @@
 %% ----------------------------------------------------------------------
 %% Imports
 
-%% UID
--import(mod_mam_utils,
-        [encode_compact_uuid/2]).
-
-%% JID serialization
--import(mod_mam_utils,
-        [jid_to_opt_binary/2,
-         expand_minified_jid/2]).
-
 %% Other
 -import(mod_mam_utils,
         [maybe_min/2,
-         maybe_max/2,
-         apply_start_border/2,
-         apply_end_border/2]).
+         maybe_max/2]).
 
 -include_lib("ejabberd/include/ejabberd.hrl").
 -include_lib("ejabberd/include/jlib.hrl").
@@ -726,12 +715,9 @@ insert_offset_hint_query_cql() ->
 
 prepare_filter(UserJID, Borders, Start, End, WithJID) ->
     BUserJID = bare_jid(UserJID),
-    StartID = maybe_encode_compact_uuid(Start, 0),
-    EndID = maybe_encode_compact_uuid(End, 255),
-    StartID2 = apply_start_border(Borders, StartID),
-    EndID2 = apply_end_border(Borders, EndID),
+    {StartID, EndID} = mod_mam_utils:calculate_msg_id_borders(Borders, Start, End),
     BWithJID = maybe_full_jid(WithJID), %% it's NOT optional field
-    prepare_filter_params(BUserJID, BWithJID, StartID2, EndID2).
+    prepare_filter_params(BUserJID, BWithJID, StartID, EndID).
 
 prepare_filter_params(BUserJID, BWithJID, StartID, EndID) ->
     #mam_ca_filter{
@@ -806,11 +792,6 @@ calc_offset(PoolName, UserJID, Host, F, _PS, _TC, #rsm_in{direction = aft, id = 
     calc_index(PoolName, UserJID, Host, F, ID);
 calc_offset(_W, _UserJID, _LS, _F, _PS, _TC, _RSM) ->
     0.
-
-maybe_encode_compact_uuid(undefined, _) ->
-    undefined;
-maybe_encode_compact_uuid(Microseconds, NodeID) ->
-    encode_compact_uuid(Microseconds, NodeID).
 
 bare_jid(undefined) -> undefined;
 bare_jid(JID) ->

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -703,10 +703,21 @@ lookup_messages(Host, ArcID, ArcJID, RSM, Borders, Start, End, Now,
         true -> %% Use of disabled full text search
             {error, 'not-supported'};
         false ->
+            Params = #{archive_id => ArcID,
+                       owner_jid => ArcJID,
+                       with_jid => WithJID,
+                       rsm => RSM,
+                       borders => Borders,
+                       start_ts => Start,
+                       end_ts => End,
+                       now => Now,
+                       search_text => SearchText,
+                       page_size => PageSize,
+                       limit_passed => LimitPassed,
+                       max_result_limit => MaxResultLimit,
+                       is_simple => IsSimple},
             ejabberd_hooks:run_fold(mam_muc_lookup_messages, Host, {ok, {0, 0, []}},
-                                    [Host, ArcID, ArcJID, RSM, Borders,
-                                     Start, End, Now, WithJID, SearchText,
-                                     PageSize, LimitPassed, MaxResultLimit, IsSimple])
+                                    [Host, Params])
     end.
 
 

--- a/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
@@ -28,11 +28,6 @@
 -import(mod_mam_utils,
         [encode_compact_uuid/2]).
 
-%% JID serialization
--import(mod_mam_utils,
-        [jid_to_opt_binary/2,
-         expand_minified_jid/2]).
-
 %% Other
 -import(mod_mam_utils,
         [maybe_min/2,
@@ -170,7 +165,7 @@ archive_message2(_Result, _Host, MessID,
                  LocJID = #jid{},
                  _RemJID = #jid{},
                  _SrcJID = #jid{lresource = BNick}, _Dir, Packet) ->
-    BLocJID = bare_jid(LocJID),
+    BLocJID = mod_mam_utils:bare_jid(LocJID),
     BPacket = packet_to_stored_binary(Packet),
     Messages = [#mam_muc_message{
                  id        = MessID,
@@ -231,7 +226,7 @@ select_for_removal_query_cql() ->
     "SELECT DISTINCT room_jid, with_nick FROM mam_muc_message WHERE room_jid = ?".
 
 remove_archive(Acc, _Host, _RoomID, RoomJID) ->
-    BRoomJID = bare_jid(RoomJID),
+    BRoomJID = mod_mam_utils:bare_jid(RoomJID),
     PoolName = pool_name(RoomJID),
     Params = #{room_jid => BRoomJID},
     %% Wait until deleted
@@ -534,7 +529,7 @@ row_to_message_id(#{id := MsgID}) ->
       Now :: unix_timestamp().
 purge_single_message(_Result, _Host, MessID, _RoomID, RoomJID, _Now) ->
     PoolName = pool_name(RoomJID),
-    BRoomJID = bare_jid(RoomJID),
+    BRoomJID = mod_mam_utils:bare_jid(RoomJID),
     Result = message_id_to_nick_name(PoolName, RoomJID, BRoomJID, MessID),
     case Result of
         {ok, BNick} ->
@@ -738,7 +733,7 @@ insert_offset_hint_query_cql() ->
     "INSERT INTO mam_muc_message_offset(room_jid, with_nick, id, offset) VALUES(?, ?, ?, ?)".
 
 prepare_filter(RoomJID, Borders, Start, End, WithNick) ->
-    BRoomJID = bare_jid(RoomJID),
+    BRoomJID = mod_mam_utils:bare_jid(RoomJID),
     StartID = maybe_encode_compact_uuid(Start, 0),
     EndID = maybe_encode_compact_uuid(End, 255),
     StartID2 = apply_start_border(Borders, StartID),
@@ -831,11 +826,6 @@ maybe_nick(undefined) ->
     <<>>;
 maybe_nick(WithNick) when is_binary(WithNick) ->
     WithNick.
-
-bare_jid(undefined) -> undefined;
-bare_jid(JID) ->
-    jid:to_binary(jid:to_bare(jid:to_lower(JID))).
-
 
 %%====================================================================
 %% Internal SQL part

--- a/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
@@ -6,6 +6,7 @@
 %%%-------------------------------------------------------------------
 -module(mod_mam_muc_cassandra_arch).
 -behaviour(mongoose_cassandra).
+-behaviour(ejabberd_gen_mam_archive).
 
 %% gen_mod handlers
 -export([start/2, stop/1]).
@@ -13,7 +14,7 @@
 %% MAM hook handlers
 -export([archive_size/4,
          archive_message/9,
-         lookup_messages/15,
+         lookup_messages/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -265,37 +266,18 @@ message_id_to_nick_name(PoolName, RoomJID, BRoomJID, MessID) ->
 %% ----------------------------------------------------------------------
 %% SELECT MESSAGES
 
--spec lookup_messages(Result :: any(), Host :: ejabberd:server(),
-                      ArchiveID :: mod_mam:archive_id(),
-                      ArchiveJID :: ejabberd:jid(),
-                      RSM :: jlib:rsm_in()  | undefined,
-                      Borders :: mod_mam:borders()  | undefined,
-                      Start :: mod_mam:unix_timestamp()  | undefined,
-                      End :: mod_mam:unix_timestamp()  | undefined,
-                      Now :: mod_mam:unix_timestamp(),
-                      WithJID :: ejabberd:jid()  | undefined,
-                      SearchText :: binary() | undefined,
-                      PageSize :: non_neg_integer(), LimitPassed :: boolean(),
-                      MaxResultLimit :: non_neg_integer(),
-                      IsSimple :: boolean()  | opt_count) ->
-                             {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
-lookup_messages(_Result, _Host,
-                _UserID, _UserJID, _RSM, _Borders,
-                _Start, _End, _Now, _WithJID, <<_SearchText/binary>>,
-                _PageSize, _LimitPassed, _MaxResultLimit,
-                _IsSimple) ->
-    {error, 'not-supported'};
-lookup_messages({error, _Reason} = Result, _Host,
-                _RoomID, _RoomJID, _RSM, _Borders,
-                _Start, _End, _Now, _WithJID, _SearchText = undefined,
-                _PageSize, _LimitPassed, _MaxResultLimit,
-                _IsSimple) ->
+-spec lookup_messages(Result :: any(), Host :: ejabberd:server(), Params :: map()) ->
+  {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
+lookup_messages({error, _Reason} = Result, _Host, _Params) ->
     Result;
+lookup_messages(_Result, _Host, #{search_text := <<_/binary>>}) ->
+    {error, 'not-supported'};
 lookup_messages(_Result, Host,
-                _RoomID, RoomJID, RSM, Borders,
-                Start, End, _Now, WithJID, _SearchText = undefined,
-                PageSize, LimitPassed, MaxResultLimit,
-                IsSimple) ->
+                #{owner_jid := RoomJID, rsm := RSM, borders := Borders,
+                  start_ts := Start, end_ts := End, with_jid := WithJID,
+                  search_text := undefined, page_size := PageSize,
+                  limit_passed := LimitPassed, max_result_limit := MaxResultLimit,
+                  is_simple := IsSimple}) ->
     try
         WithNick = maybe_jid_to_nick(WithJID),
         PoolName = pool_name(RoomJID),

--- a/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
@@ -20,7 +20,7 @@
 
 -export([archive_size/4,
          archive_message/9,
-         lookup_messages/15,
+         lookup_messages/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -189,17 +189,14 @@ prepare_insert(Name, NumRows) ->
     ok.
 
 
-lookup_messages({error, _Reason}=Result, _Host,
-                _UserID, _UserJID, _RSM, _Borders,
-                _Start, _End, _Now, _WithJID, _SearchText,
-                _PageSize, _LimitPassed, _MaxResultLimit,
-                _IsSimple) ->
+lookup_messages({error, _Reason}=Result, _Host, _Params) ->
     Result;
 lookup_messages(_Result, Host,
-                UserID, UserJID, RSM, Borders,
-                Start, End, Now, WithJID, SearchText,
-                PageSize, LimitPassed, MaxResultLimit,
-                IsSimple) ->
+                #{archive_id := UserID, owner_jid := UserJID, rsm := RSM,
+                  borders := Borders, start_ts := Start, end_ts := End, now := Now,
+                  with_jid := WithJID, search_text := SearchText, page_size := PageSize,
+                  limit_passed := LimitPassed, max_result_limit := MaxResultLimit,
+                  is_simple := IsSimple}) ->
     try
         lookup_messages(Host,
                         UserID, UserJID, RSM, Borders,

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
@@ -16,7 +16,7 @@
 -behaviour(ejabberd_gen_mam_archive).
 -export([archive_size/4,
          archive_message/9,
-         lookup_messages/15,
+         lookup_messages/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -231,20 +231,9 @@ archive_size(Size, Host, ArcID, _ArcJID) when is_integer(Size) ->
     Size.
 
 
--spec lookup_messages(Result :: any(), Host :: ejabberd:server(),
-                      ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid(),
-                      RSM :: jlib:rsm_in() | undefined, Borders :: mod_mam:borders() | undefined,
-                      Start :: mod_mam:unix_timestamp() | undefined,
-                      End :: mod_mam:unix_timestamp() | undefined, Now :: mod_mam:unix_timestamp(),
-                      WithJID :: ejabberd:jid() | undefined,
-                      _SearchText :: binary() | undefined, PageSize :: integer(),
-                      LimitPassed :: boolean() | opt_count, MaxResultLimit :: integer(),
-                      IsSimple :: boolean()) -> {ok, mod_mam:lookup_result()}
-                                                    | {error, 'policy-violation'}.
-lookup_messages(Result, Host, ArcID, _ArcJID,
-                _RSM, _Borders,
-                _Start, End, Now, _WithJID, _SearchText,
-                _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+-spec lookup_messages(Result :: any(), Host :: ejabberd:server(), Params :: map()) ->
+    {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
+lookup_messages(Result, Host, #{archive_id := ArcID, end_ts := End, now := Now}) ->
     wait_flushing_before(Host, ArcID, End, Now),
     Result.
 

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -22,7 +22,7 @@
 
 -export([archive_size/4,
          archive_message/9,
-         lookup_messages/15,
+         lookup_messages/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -269,32 +269,26 @@ prepare_insert(Name, NumRows) ->
     mongoose_rdbms:prepare(Name, Table, Fields, Query),
     ok.
 
--spec lookup_messages(Result :: any(), Host :: ejabberd:server(),
-                      ArchiveID :: mod_mam:archive_id(),
-                      ArchiveJID :: ejabberd:jid(),
-                      RSM :: jlib:rsm_in()  | undefined,
-                      Borders :: mod_mam:borders()  | undefined,
-                      Start :: mod_mam:unix_timestamp()  | undefined,
-                      End :: mod_mam:unix_timestamp()  | undefined,
-                      Now :: mod_mam:unix_timestamp(),
-                      WithJID :: ejabberd:jid()  | undefined,
-                      SearchText :: binary() | undefined,
-                      PageSize :: non_neg_integer(), LimitPassed :: boolean(),
-                      MaxResultLimit :: non_neg_integer(),
-                      IsSimple :: boolean()  | opt_count) ->
+-spec lookup_messages(Result :: any(), Host :: ejabberd:server(), Params :: map()) ->
                              {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
-lookup_messages({error, _Reason}=Result, _Host,
-                _UserID, _UserJID, _RSM, _Borders,
-                _Start, _End, _Now, _WithJID, _SearchText,
-                _PageSize, _LimitPassed, _MaxResultLimit,
-                _IsSimple) ->
+lookup_messages({error, _Reason}=Result, _Host, _Params) ->
     Result;
-lookup_messages(_Result, Host,
-                UserID, UserJID, RSM, Borders,
-                Start, End, Now, WithJID, SearchText,
-                PageSize, LimitPassed, MaxResultLimit,
-                IsSimple) ->
+lookup_messages(_Result, Host, Params) ->
     try
+        UserID = maps:get(archive_id, Params),
+        UserJID = maps:get(owner_jid, Params),
+        RSM = maps:get(rsm, Params),
+        Borders = maps:get(borders, Params),
+        Start = maps:get(start_ts, Params),
+        End = maps:get(end_ts, Params),
+        Now = maps:get(now, Params),
+        WithJID = maps:get(with_jid, Params),
+        SearchText = maps:get(search_text, Params),
+        PageSize = maps:get(page_size, Params),
+        LimitPassed = maps:get(limit_passed, Params),
+        MaxResultLimit = maps:get(max_result_limit, Params),
+        IsSimple = maps:get(is_simple, Params),
+
         do_lookup_messages(Host,
                            UserID, UserJID, RSM, Borders,
                            Start, End, Now, WithJID,

--- a/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
@@ -16,7 +16,7 @@
 -behaviour(ejabberd_gen_mam_archive).
 -export([archive_size/4,
          archive_message/9,
-         lookup_messages/15,
+         lookup_messages/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -241,23 +241,11 @@ archive_size(Size, Host, ArcID, _ArcJID) when is_integer(Size) ->
     Size.
 
 
--spec lookup_messages(Result :: any(), Host :: ejabberd:server(),
-                      ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid(),
-                      RSM :: jlib:rsm_in() | undefined, Borders :: mod_mam:borders() | undefined,
-                      Start :: mod_mam:unix_timestamp() | undefined,
-                      End :: mod_mam:unix_timestamp() | undefined, Now :: mod_mam:unix_timestamp(),
-                      WithJID :: ejabberd:jid() | undefined,
-                      SearchText :: binary() | undefined, PageSize :: integer(),
-                      LimitPassed :: boolean() | opt_count, MaxResultLimit :: integer(),
-                      IsSimple :: boolean()) -> {ok, mod_mam:lookup_result()}
-                                                    | {error, 'policy-violation'}.
-lookup_messages(Result, Host, ArcID, _ArcJID,
-                _RSM, _Borders,
-                _Start, End, Now, _WithJID, _SearchText,
-                _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+-spec lookup_messages(Result :: any(), Host :: ejabberd:server(), Params :: map()) ->
+    {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
+lookup_messages(Result, Host, #{archive_id := ArcID, end_ts := End, now := Now}) ->
     wait_flushing_before(Host, ArcID, End, Now),
     Result.
-
 
 %% #rh
 -spec remove_archive(Acc :: map(), Host :: ejabberd:server(),

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -29,14 +29,14 @@
 -export([start/2,
          stop/1,
          archive_size/4,
-         lookup_messages/12,
+         lookup_messages/2,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
 -export([archive_message/9,
          archive_message_muc/9,
-         lookup_messages/15,
+         lookup_messages/3,
          lookup_messages_muc/15]).
 
 -export([key/3]).
@@ -147,22 +147,11 @@ maybe_muc_jid(Other) ->
     Other.
 
 
-lookup_messages({error, _Reason} = Result, _Host,
-                _UserID, _UserJID, _RSM, _Borders,
-                _Start, _End, _Now, _WithJID, _SearchText,
-                _PageSize, _LimitPassed, _MaxResultLimit,
-                _IsSimple) ->
+lookup_messages({error, _Reason} = Result, _Host, _Params) ->
     Result;
-lookup_messages(_Result, Host,
-                _UserID, UserJID, RSM, Borders,
-                Start, End, _Now, WithJID, SearchText,
-                PageSize, LimitPassed, MaxResultLimit,
-                IsSimple) ->
+lookup_messages(_Result, Host, Params) ->
     try
-        lookup_messages(Host, UserJID, RSM, Borders,
-                        Start, End, WithJID, SearchText,
-                        PageSize, LimitPassed, MaxResultLimit,
-                        IsSimple)
+        lookup_messages(Host, Params)
     catch _Type:Reason ->
               S = erlang:get_stacktrace(),
               {error, {Reason, {stacktrace, S}}}
@@ -175,11 +164,20 @@ lookup_messages_muc(Result, Host,
                     PageSize, LimitPassed, MaxResultLimit,
                     IsSimple) ->
     WithJIDMuc = maybe_muc_jid(WithJID),
-    lookup_messages(Result, Host,
-                    UserID, UserJID, RSM, Borders,
-                    Start, End, Now, WithJIDMuc, SearchText,
-                    PageSize, LimitPassed, MaxResultLimit,
-                    IsSimple).
+            Params = #{archive_id => UserID,
+                       owner_jid => UserJID,
+                       with_jid => WithJIDMuc,
+                       rsm => RSM,
+                       borders => Borders,
+                       start_ts => Start,
+                       end_ts => End,
+                       now => Now,
+                       search_text => SearchText,
+                       page_size => PageSize,
+                       limit_passed => LimitPassed,
+                       max_result_limit => MaxResultLimit,
+                       is_simple => IsSimple},
+    lookup_messages(Result, Host, Params).
 
 
 archive_size(_Size, _Host, _ArchiveID, ArchiveJID) ->
@@ -255,23 +253,28 @@ create_obj(Host, MsgId, SourceJID, Packet, Type) ->
 
     mongoose_riak:create_new_map(Ops).
 
-lookup_messages(Host, ArchiveJID, RSM, Borders, Start, End,
-                WithJID, SearchText, PageSize, LimitPassed, MaxResultLimit, IsSimple) ->
-    OwnerJID = bare_jid(ArchiveJID),
-    RemoteJID = bare_jid(WithJID),
+lookup_messages(Host, Params) ->
+    OwnerJID = bare_jid(maps:get(owner_jid, Params)),
+    RemoteJID = bare_jid(maps:get(with_jid, Params)),
 
-    SearchOpts2 = add_sorting(RSM, [{rows, PageSize}]),
+    RSM = maps:get(rsm, Params),
+
+    SearchOpts2 = add_sorting(RSM, [{rows, maps:get(page_size, Params)}]),
     SearchOpts = add_offset(RSM, SearchOpts2),
 
     F = fun get_msg_id_key/3,
 
+    Borders = maps:get(borders, Params),
+    Start = maps:get(start_ts, Params),
+    End = maps:get(end_ts, Params),
+    SearchText = maps:get(search_text, Params),
     {MsgIdStart, MsgIdEnd} = calculate_msg_id_borders(RSM, Borders, Start, End),
     {TotalCountFullQuery, Result} = read_archive(OwnerJID, RemoteJID,
                                                  MsgIdStart, MsgIdEnd, SearchText,
                                                  SearchOpts, F),
 
     SortedKeys = sort_messages(Result),
-    case IsSimple of
+    case maps:get(is_simple, Params) of
         true ->
             {ok, {undefined, undefined, get_messages(Host, SortedKeys)}};
         _ ->
@@ -282,6 +285,8 @@ lookup_messages(Host, ArchiveJID, RSM, Borders, Start, End,
                                            [{rows, 1}], F),
             Offset = calculate_offset(RSM, TotalCountFullQuery, length(SortedKeys),
                                       {OwnerJID, RemoteJID, MsgIdStartNoRSM, SearchText}),
+            LimitPassed = maps:get(limit_passed, Params),
+            MaxResultLimit = maps:get(max_result_limit, Params),
             case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
                 true ->
                     {error, 'policy-violation'};

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -37,7 +37,7 @@
 -export([archive_message/9,
          archive_message_muc/9,
          lookup_messages/3,
-         lookup_messages_muc/15]).
+         lookup_messages_muc/3]).
 
 -export([key/3]).
 
@@ -158,26 +158,9 @@ lookup_messages(_Result, Host, Params) ->
     end.
 
 
-lookup_messages_muc(Result, Host,
-                    UserID, UserJID, RSM, Borders,
-                    Start, End, Now, WithJID, SearchText,
-                    PageSize, LimitPassed, MaxResultLimit,
-                    IsSimple) ->
+lookup_messages_muc(Result, Host, #{with_jid := WithJID} = Params) ->
     WithJIDMuc = maybe_muc_jid(WithJID),
-            Params = #{archive_id => UserID,
-                       owner_jid => UserJID,
-                       with_jid => WithJIDMuc,
-                       rsm => RSM,
-                       borders => Borders,
-                       start_ts => Start,
-                       end_ts => End,
-                       now => Now,
-                       search_text => SearchText,
-                       page_size => PageSize,
-                       limit_passed => LimitPassed,
-                       max_result_limit => MaxResultLimit,
-                       is_simple => IsSimple},
-    lookup_messages(Result, Host, Params).
+    lookup_messages(Result, Host, Params#{with_jid => WithJIDMuc}).
 
 
 archive_size(_Size, _Host, _ArchiveID, ArchiveJID) ->

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -181,7 +181,7 @@ lookup_messages_muc(Result, Host,
 
 
 archive_size(_Size, _Host, _ArchiveID, ArchiveJID) ->
-    OwnerJID = bare_jid(ArchiveJID),
+    OwnerJID = mod_mam_utils:bare_jid(ArchiveJID),
     RemoteJID = undefined,
     {MsgIdStartNoRSM, MsgIdEndNoRSM} =
         calculate_msg_id_borders(undefined, undefined, undefined, undefined),
@@ -219,9 +219,9 @@ remove_bucket(Bucket) ->
     [mongoose_riak:delete(Bucket, Key) || Key <- Keys].
 
 archive_message(Host, MessID, LocJID, RemJID, SrcJID, Packet, Type) ->
-    LocalJID = bare_jid(LocJID),
-    RemoteJID = bare_jid(RemJID),
-    SourceJID = full_jid(SrcJID),
+    LocalJID = mod_mam_utils:bare_jid(LocJID),
+    RemoteJID = mod_mam_utils:bare_jid(RemJID),
+    SourceJID = mod_mam_utils:full_jid(SrcJID),
     MsgId = integer_to_binary(MessID),
     Key = key(LocalJID, RemoteJID, MsgId),
 
@@ -254,8 +254,8 @@ create_obj(Host, MsgId, SourceJID, Packet, Type) ->
     mongoose_riak:create_new_map(Ops).
 
 lookup_messages(Host, Params) ->
-    OwnerJID = bare_jid(maps:get(owner_jid, Params)),
-    RemoteJID = bare_jid(maps:get(with_jid, Params)),
+    OwnerJID = mod_mam_utils:bare_jid(maps:get(owner_jid, Params)),
+    RemoteJID = mod_mam_utils:bare_jid(maps:get(with_jid, Params)),
 
     RSM = maps:get(rsm, Params),
 
@@ -354,7 +354,7 @@ remove_archive(Host, _ArchiveID, ArchiveJID) ->
     end.
 
 remove_chunk(_Host, ArchiveJID, Acc) ->
-    KeyFiletrs = key_filters(bare_jid(ArchiveJID)),
+    KeyFiletrs = key_filters(mod_mam_utils:bare_jid(ArchiveJID)),
     fold_archive(fun delete_key_fun/3,
                  KeyFiletrs,
                  [{rows, 50}, {sort, <<"msg_id_register asc">>}], Acc).
@@ -369,14 +369,14 @@ do_remove_archive(N, {ok, _TotalResults, _RowsIterated, Acc}, Host, ArchiveJID) 
     do_remove_archive(N-1, R, Host, ArchiveJID).
 
 purge_single_message(_Result, _Host, MessID, _ArchiveID, ArchiveJID, _Now) ->
-    ArchiveJIDBin = bare_jid(ArchiveJID),
+    ArchiveJIDBin = mod_mam_utils:bare_jid(ArchiveJID),
     KeyFilters = key_filters(ArchiveJIDBin, MessID),
     {ok, 1, 1, 1} = fold_archive(fun delete_key_fun/3, KeyFilters, [], 0),
     ok.
 
 purge_multiple_messages(_Result, _Host, _ArchiveID,
                         ArchiveJID, _Borders, Start, End, _Now, WithJID) ->
-    ArchiveJIDBin = bare_jid(ArchiveJID),
+    ArchiveJIDBin = mod_mam_utils:bare_jid(ArchiveJID),
     KeyFilters = key_filters(ArchiveJIDBin, WithJID, Start, End),
     {ok, Total, _Iterated, Deleted} =
         fold_archive(fun delete_key_fun/3,
@@ -506,16 +506,6 @@ calculate_msg_id_borders(#rsm_in{direction = before, id = Id}, Borders, Start, E
     {StartId, mod_mam_utils:maybe_min(EndId, PrevId)};
 calculate_msg_id_borders(_, Borders, Start, End) ->
     mod_mam_utils:calculate_msg_id_borders(Borders, Start, End).
-
-bare_jid(undefined) -> undefined;
-bare_jid(JID) ->
-    jid:to_binary(jid:to_bare(jid:to_lower(JID))).
-
-full_jid(undefined) -> undefined;
-full_jid(JID) ->
-    jid:to_binary(jid:to_lower(JID)).
-
-
 
 %% ----------------------------------------------------------------------
 %% Optimizations

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -497,18 +497,15 @@ solr_id_filters(Start, End) ->
 calculate_msg_id_borders(#rsm_in{id = undefined}, Borders, Start, End) ->
     calculate_msg_id_borders(undefined, Borders, Start, End);
 calculate_msg_id_borders(#rsm_in{direction = aft, id = Id}, Borders, Start, End) ->
-    {StartId, EndId} = calculate_msg_id_borders(undefined, Borders, Start, End),
+    {StartId, EndId} = mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
     NextId = Id + 1,
     {mod_mam_utils:maybe_max(StartId, NextId), EndId};
 calculate_msg_id_borders(#rsm_in{direction = before, id = Id}, Borders, Start, End) ->
-    {StartId, EndId} = calculate_msg_id_borders(undefined, Borders, Start, End),
+    {StartId, EndId} = mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
     PrevId = Id - 1,
     {StartId, mod_mam_utils:maybe_min(EndId, PrevId)};
-calculate_msg_id_borders(_RSM, Borders, Start, End) ->
-    StartID = maybe_encode_compact_uuid(Start, 0),
-    EndID = maybe_encode_compact_uuid(End, 255),
-    {mod_mam_utils:apply_start_border(Borders, StartID),
-     mod_mam_utils:apply_end_border(Borders, EndID)}.
+calculate_msg_id_borders(_, Borders, Start, End) ->
+    mod_mam_utils:calculate_msg_id_borders(Borders, Start, End).
 
 bare_jid(undefined) -> undefined;
 bare_jid(JID) ->
@@ -518,11 +515,6 @@ full_jid(undefined) -> undefined;
 full_jid(JID) ->
     jid:to_binary(jid:to_lower(JID)).
 
-
-maybe_encode_compact_uuid(undefined, _) ->
-    undefined;
-maybe_encode_compact_uuid(Microseconds, NodeID) ->
-    mod_mam_utils:encode_compact_uuid(Microseconds, NodeID).
 
 
 %% ----------------------------------------------------------------------

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -184,7 +184,7 @@ archive_size(_Size, _Host, _ArchiveID, ArchiveJID) ->
     OwnerJID = mod_mam_utils:bare_jid(ArchiveJID),
     RemoteJID = undefined,
     {MsgIdStartNoRSM, MsgIdEndNoRSM} =
-        calculate_msg_id_borders(undefined, undefined, undefined, undefined),
+    mod_mam_utils:calculate_msg_id_borders(undefined, undefined, undefined, undefined),
     F = fun get_msg_id_key/3,
     {TotalCount, _} = read_archive(OwnerJID, RemoteJID,
                                    MsgIdStartNoRSM, MsgIdEndNoRSM, undefined,
@@ -268,7 +268,7 @@ lookup_messages(Host, Params) ->
     Start = maps:get(start_ts, Params),
     End = maps:get(end_ts, Params),
     SearchText = maps:get(search_text, Params),
-    {MsgIdStart, MsgIdEnd} = calculate_msg_id_borders(RSM, Borders, Start, End),
+    {MsgIdStart, MsgIdEnd} = mod_mam_utils:calculate_msg_id_borders(RSM, Borders, Start, End),
     {TotalCountFullQuery, Result} = read_archive(OwnerJID, RemoteJID,
                                                  MsgIdStart, MsgIdEnd, SearchText,
                                                  SearchOpts, F),
@@ -279,7 +279,7 @@ lookup_messages(Host, Params) ->
             {ok, {undefined, undefined, get_messages(Host, SortedKeys)}};
         _ ->
             {MsgIdStartNoRSM, MsgIdEndNoRSM} =
-                calculate_msg_id_borders(undefined, Borders, Start, End),
+            mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
             {TotalCount, _} = read_archive(OwnerJID, RemoteJID,
                                            MsgIdStartNoRSM, MsgIdEndNoRSM, SearchText,
                                            [{rows, 1}], F),
@@ -492,20 +492,6 @@ id_filters(StartInt, EndInt) ->
 
 solr_id_filters(Start, End) ->
     <<"msg_id_register:[", Start/binary, " TO ", End/binary, " ]">>.
-
-
-calculate_msg_id_borders(#rsm_in{id = undefined}, Borders, Start, End) ->
-    calculate_msg_id_borders(undefined, Borders, Start, End);
-calculate_msg_id_borders(#rsm_in{direction = aft, id = Id}, Borders, Start, End) ->
-    {StartId, EndId} = mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
-    NextId = Id + 1,
-    {mod_mam_utils:maybe_max(StartId, NextId), EndId};
-calculate_msg_id_borders(#rsm_in{direction = before, id = Id}, Borders, Start, End) ->
-    {StartId, EndId} = mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
-    PrevId = Id - 1,
-    {StartId, mod_mam_utils:maybe_min(EndId, PrevId)};
-calculate_msg_id_borders(_, Borders, Start, End) ->
-    mod_mam_utils:calculate_msg_id_borders(Borders, Start, End).
 
 %% ----------------------------------------------------------------------
 %% Optimizations

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -74,6 +74,8 @@
          maybe_max/2,
          apply_start_border/2,
          apply_end_border/2,
+         bare_jid/1,
+         full_jid/1,
          calculate_msg_id_borders/3,
          maybe_encode_compact_uuid/2,
          is_last_page/4]).
@@ -826,6 +828,14 @@ is_loaded_application(AppName) when is_atom(AppName) ->
 
 %% -----------------------------------------------------------------------
 %% Other
+-spec bare_jid(undefined | ejabberd:jid()) -> undefined | binary().
+bare_jid(undefined) -> undefined;
+bare_jid(JID) ->
+    jid:to_binary(jid:to_bare(jid:to_lower(JID))).
+
+-spec full_jid(ejabberd:jid()) -> binary().
+full_jid(JID) ->
+    jid:to_binary(jid:to_lower(JID)).
 
 -spec maybe_integer(binary(), Default :: integer()) -> integer().
 maybe_integer(<<>>, Def) -> Def;

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -74,6 +74,8 @@
          maybe_max/2,
          apply_start_border/2,
          apply_end_border/2,
+         calculate_msg_id_borders/3,
+         maybe_encode_compact_uuid/2,
          is_last_page/4]).
 
 %% Ejabberd
@@ -844,6 +846,23 @@ apply_end_border(undefined, EndID) ->
     EndID;
 apply_end_border(#mam_borders{before_id=BeforeID, to_id=ToID}, EndID) ->
     maybe_min(maybe_previous_id(BeforeID), maybe_min(ToID, EndID)).
+
+-spec calculate_msg_id_borders(mod_mam:borders() | undefined,
+                               mod_mam:unix_timestamp() | undefined,
+                               mod_mam:unix_timestamp() | undefined) -> R when
+      R :: {integer() | undefined, integer() | undefined}.
+calculate_msg_id_borders(Borders, Start, End) ->
+    StartID = maybe_encode_compact_uuid(Start, 0),
+    EndID = maybe_encode_compact_uuid(End, 255),
+    {apply_start_border(Borders, StartID),
+     apply_end_border(Borders, EndID)}.
+
+-spec maybe_encode_compact_uuid(mod_mam:unix_timestamp() | undefined, integer()) ->
+    undefined | integer().
+maybe_encode_compact_uuid(undefined, _) ->
+    undefined;
+maybe_encode_compact_uuid(Microseconds, NodeID) ->
+    mod_mam_utils:encode_compact_uuid(Microseconds, NodeID).
 
 
 -spec maybe_min('undefined' | integer(), undefined | integer()) -> integer().

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -77,6 +77,7 @@
          bare_jid/1,
          full_jid/1,
          calculate_msg_id_borders/3,
+         calculate_msg_id_borders/4,
          maybe_encode_compact_uuid/2,
          is_last_page/4]).
 
@@ -866,6 +867,24 @@ calculate_msg_id_borders(Borders, Start, End) ->
     EndID = maybe_encode_compact_uuid(End, 255),
     {apply_start_border(Borders, StartID),
      apply_end_border(Borders, EndID)}.
+
+-spec calculate_msg_id_borders(rsm_in() | undefined,
+                               mod_mam:borders() | undefined,
+                               mod_mam:unix_timestamp() | undefined,
+                               mod_mam:unix_timestamp() | undefined) -> R when
+      R :: {integer() | undefined, integer() | undefined}.
+calculate_msg_id_borders(#rsm_in{id = undefined}, Borders, Start, End) ->
+    calculate_msg_id_borders(undefined, Borders, Start, End);
+calculate_msg_id_borders(#rsm_in{direction = aft, id = Id}, Borders, Start, End) ->
+    {StartId, EndId} = mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
+    NextId = Id + 1,
+    {mod_mam_utils:maybe_max(StartId, NextId), EndId};
+calculate_msg_id_borders(#rsm_in{direction = before, id = Id}, Borders, Start, End) ->
+    {StartId, EndId} = mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
+    PrevId = Id - 1,
+    {StartId, mod_mam_utils:maybe_min(EndId, PrevId)};
+calculate_msg_id_borders(_, Borders, Start, End) ->
+    mod_mam_utils:calculate_msg_id_borders(Borders, Start, End).
 
 -spec maybe_encode_compact_uuid(mod_mam:unix_timestamp() | undefined, integer()) ->
     undefined | integer().

--- a/apps/ejabberd/src/mongoose_metrics_mam_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_mam_hooks.erl
@@ -18,7 +18,7 @@
 -export([mam_get_prefs/4,
          mam_set_prefs/7,
          mam_remove_archive/4,
-         mam_lookup_messages/15,
+         mam_lookup_messages/3,
          mam_archive_message/9,
          mam_flush_messages/3,
          mam_drop_message/2,
@@ -93,10 +93,7 @@ mam_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
     Acc.
 
 mam_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
-    Host, _ArcID, _ArcJID,
-    _RSM, _Borders,
-    _Start, _End, _Now, _WithJID, _SearchText,
-    _PageSize, _LimitPassed, _MaxResultLimit, IsSimple) ->
+                    Host, #{is_simple := IsSimple}) ->
     mongoose_metrics:update(Host, modMamForwarded, length(MessageRows)),
     mongoose_metrics:update(Host, modMamLookups, 1),
     case IsSimple of
@@ -106,11 +103,7 @@ mam_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
             ok
     end,
     Result;
-mam_lookup_messages(Result = {error, _},
-    _Host, _ArcID, _ArcJID,
-    _RSM, _Borders,
-    _Start, _End, _Now, _WithJID, _SearchText,
-    _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+mam_lookup_messages(Result = {error, _}, _Host, _Params) ->
     Result.
 
 -spec mam_archive_message(Result :: any(), Host :: ejabberd:server(),

--- a/apps/ejabberd/src/mongoose_metrics_mam_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_mam_hooks.erl
@@ -29,7 +29,7 @@
          mam_muc_get_prefs/4,
          mam_muc_set_prefs/7,
          mam_muc_remove_archive/4,
-         mam_muc_lookup_messages/15,
+         mam_muc_lookup_messages/3,
          mam_muc_archive_message/9,
          mam_muc_flush_messages/3,
          mam_muc_drop_message/1,
@@ -169,18 +169,12 @@ mam_muc_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
     Acc.
 
 mam_muc_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
-    Host, _ArcID, _ArcJID,
-    _RSM, _Borders,
-    _Start, _End, _Now, _WithJID, _SearchText,
-    _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+    Host, _Params) ->
     mongoose_metrics:update(Host, modMucMamForwarded, length(MessageRows)),
     mongoose_metrics:update(Host, modMucMamLookups, 1),
     Result;
 mam_muc_lookup_messages(Result = {error, _},
-    _Host, _ArcID, _ArcJID,
-    _RSM, _Borders,
-    _Start, _End, _Now, _WithJID, _SearchText,
-    _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+    _Host, _Params) ->
     Result.
 
 


### PR DESCRIPTION
Proposed changes include:
* refactored lookup_messages hook for `pm` and `muc` archive - uses map for all parameters now
* some MAM specific jid helper functions where moved to `mod_mam_utils`
* msg_id border calculation functions were moved to `mod_mam_utils`

