### PR TITLE
add ejabberd_router:route_error_reply/4

### DIFF
--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -32,6 +32,7 @@
 -export([route/3,
          route/4,
          route_error/4,
+         route_error_reply/4,
          register_route/2,
          register_routes/2,
          unregister_route/1,
@@ -125,6 +126,13 @@ route_error(From, To, Acc, ErrPacket) ->
         true ->
             Acc
     end.
+
+-spec route_error_reply(ejabberd:jid(), ejabberd:jid(), mongoose_acc:t(), exml:element()) ->
+    mongoose_acc:t().
+route_error_reply(From, To, Acc, Error) ->
+    ErrorReply = jlib:make_error_reply(Acc, Error),
+    route_error(From, To, Acc, ErrorReply).
+
 
 -spec register_components([Domain :: domain()],
                           Handler :: mongoose_packet_handler:t()) -> ok | {error, any()}.

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -368,8 +368,7 @@ handle_info({route, From, To, Acc}, StateName, StateData) ->
            Text = exml:to_binary(#xmlel{name = Name, attrs = Attrs2, children = Els}),
            send_text(StateData, Text);
         deny ->
-            Err = jlib:make_error_reply(Packet, ?ERR_NOT_ALLOWED),
-            ejabberd_router:route_error(To, From, Acc, Err)
+            ejabberd_router:route_error_reply(To, From, Acc, ?ERR_NOT_ALLOWED)
     end,
     {next_state, StateName, StateData};
 handle_info({'DOWN', Monitor, _Type, _Object, _Info}, _StateName, StateData)

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -500,9 +500,8 @@ process_packet(From, To, Acc, #state{
             #xmlel{attrs = Attrs} = Packet,
             Lang = xml:get_attr_s(<<"xml:lang">>, Attrs),
             ErrText = <<"Access denied by service policy">>,
-            Err = jlib:make_error_reply(Packet,
-                                        ?ERRT_FORBIDDEN(Lang, ErrText)),
-            ejabberd_router:route_error(To, From, Acc, Err)
+            ejabberd_router:route_error_reply(To, From, Acc,
+                                              ?ERRT_FORBIDDEN(Lang, ErrText))
     end.
 
 


### PR DESCRIPTION
Takes Error element instead of packet and adds it to the original packet

This PR addresses #

Proposed changes include:
* describe the functionality changes
* describe new or updated tests
* describe changes to the documentation

