### PR TITLE
Extend tracked backend function with count metric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: erlang
-dist: trusty
+dist: xenial
 sudo: required
 addons:
     apt:

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1071,7 +1071,7 @@ stop_module(Host, Mod) ->
     end.
 
 just_stop_module(Host, Mod) ->
-    ok = rpc_apply(gen_mod, stop_module, [Host, Mod]).
+    {ok, _Opts} = rpc_apply(gen_mod, stop_module, [Host, Mod]).
 
 %%--------------------------------------------------------------------
 %% Group name helpers

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -470,7 +470,7 @@ stop_start_command_module(_) ->
     %% described above we test both transition from `started' to
     %% `stopped' and from `stopped' to `started'.
     {?OK, _} = gett(admin, <<"/commands">>),
-    ok = dynamic_modules:stop(host(), mod_commands),
+    {ok, _Opts} = dynamic_modules:stop(host(), mod_commands),
     {?NOT_FOUND, _} = gett(admin, <<"/commands">>),
     {ok, _} = dynamic_modules:start(host(), mod_commands, []),
     timer:sleep(200), %% give the server some time to build the paths again

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -35,16 +35,24 @@ Node configuration still uses the default configuration defined by the node plug
 
 #### Note about RDBMS backend
 
-Current RDBMS backend replaces `pubsub_state` and `pubsub_item` Mnesia tables with RDBMS equivalents.
+Current RDBMS backend replaces `pubsub_node`, `pubsub_state` and `pubsub_item` Mnesia tables with RDBMS equivalents.
 Due to a fact that some data is still maintained in Mnesia, there is a certain risk of data becoming inconsistent.
 The schema used by this backend may change until it reaches stable status.
+
+#### Cache Backend
+
+Although it is not a default setting, the cache backend can be configured
+to use Mnesia or RDBMS. It allows storing the `pubsub_last_item` table
+separately. For example you can configure `backend` to use `rdbms` and
+`last_item_cache` to use `mnesia`.
 
 ### Example Configuration
 
 ```
    {mod_pubsub, [{access_createnode, pubsub_createnode},
                  {ignore_pep_from_offline, false},
-                 {last_item_cache, true},
+                 {backend, rdbms},
+                 {last_item_cache, mnesia},
                  {max_items_node, 1000},
                  {plugins, [<<"flat">>, <<"pep">>]}
   ]},

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -63,6 +63,7 @@
 
          loaded_modules/1,
          loaded_modules_with_opts/1,
+         opts_for_module/2,
          get_module_proc/2,
          is_loaded/2,
          get_deps/3]).
@@ -190,7 +191,7 @@ is_app_running(AppName) ->
 
 %% @doc Stop the module in a host, and forget its configuration.
 -spec stop_module(jid:server(), module()) ->
-    ok | {error, not_loaded} | {error, term()}.
+    {ok, list()} | {error, not_loaded} | {error, term()}.
 stop_module(Host, Module) ->
     case is_loaded(Host, Module) of
         false -> {error, not_loaded};
@@ -199,21 +200,22 @@ stop_module(Host, Module) ->
 
 stop_module_for_host(Host, Module) ->
     case stop_module_keep_config(Host, Module) of
-        ok ->
+        {ok, Opts} ->
             case del_module_mnesia(Host, Module) of
-                {atomic, _} -> ok;
+                {atomic, _} -> {ok, Opts};
                 E -> {error, E}
             end;
-        E ->
-            E
+        {error, E} ->
+            {error, E}
     end.
 
 %% @doc Stop the module in a host, but keep its configuration. As the module
 %% configuration is kept in the Mnesia local_config table, when ejabberd is
 %% restarted the module will be started again. This function is useful when
 %% ejabberd is being stopped and it stops all modules.
--spec stop_module_keep_config(jid:server(), module()) -> {error, term()} | 'ok'.
+-spec stop_module_keep_config(jid:server(), module()) -> {error, term()} | {ok, list()}.
 stop_module_keep_config(Host, Module) ->
+    Opts = opts_for_module(Host, Module),
     case catch Module:stop(Host) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("~p", [Reason]),
@@ -221,14 +223,14 @@ stop_module_keep_config(Host, Module) ->
         {wait, ProcList} when is_list(ProcList) ->
             lists:foreach(fun wait_for_process/1, ProcList),
             ets:delete(ejabberd_modules, {Module, Host}),
-            ok;
+            {ok, Opts};
         {wait, Process} ->
             wait_for_process(Process),
             ets:delete(ejabberd_modules, {Module, Host}),
-            ok;
+            {ok, Opts};
         _ ->
             ets:delete(ejabberd_modules, {Module, Host}),
-            ok
+            {ok, Opts}
     end.
 
 -spec reload_module(jid:server(), module(), [any()]) -> {ok, term()} | {error, already_started}.
@@ -385,6 +387,17 @@ loaded_modules_with_opts(Host) ->
                  [],
                  [{{'$1', '$2'}}]}]).
 
+-spec opts_for_module(ejabberd:server(), module()) -> list().
+opts_for_module(Host, Module) ->
+    case ets:select(ejabberd_modules,
+                    [{#ejabberd_module{_ = '_',
+                                       module_host = {Module, Host},
+                                       opts = '$1'},
+                      [],
+                      [{{'$1'}}]}]) of
+        [{Opts}] -> Opts;
+        []       -> []
+    end.
 
 -spec set_module_opts_mnesia(jid:server(), module(), [any()]
                             ) -> {'aborted', _} | {'atomic', _}.
@@ -440,7 +453,6 @@ clear_opts(Module, Opts0) ->
         _ ->
             Opts
     end.
-
 
 -spec get_deps(Host :: jid:server(), Module :: module(),
                Opts :: proplists:proplist()) -> deps_list().

--- a/src/pubsub/gen_pubsub_nodetree.erl
+++ b/src/pubsub/gen_pubsub_nodetree.erl
@@ -51,7 +51,7 @@
 -callback terminate(Host :: host(), ServerHost :: binary()) -> atom().
 
 -callback set_node(PubsubNode :: pubsubNode()) ->
-    ok | {result, NodeIdx::nodeIdx()} | {error, exml:element()}.
+    {ok, NodeIdx::nodeIdx()} | {error, exml:element()}.
 
 -callback get_node(Host :: host(), NodeId :: nodeId()) -> pubsubNode() | {error, exml:element()}.
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -267,7 +267,6 @@ init([ServerHost, Opts]) ->
 
     init_backend(Opts),
 
-    pubsub_index:init(Host, ServerHost, Opts),
     ets:new(gen_mod:get_module_proc(ServerHost, config), [set, named_table, public]),
     {Plugins, NodeTree, PepMapping} = init_plugins(Host, ServerHost, Opts),
 
@@ -2856,7 +2855,7 @@ get_sub_options_xml(Host, JID, _Lang, Node, Nidx, RequestedSubId, Type) ->
                                            <<"invalid-subid">>)}
             end
     end.
-    
+
 make_and_wrap_sub_xform(Options, Node, Subscriber, SubId) ->
     {ok, XForm} = pubsub_form_utils:make_sub_xform(Options),
     OptionsEl = #xmlel{name = <<"options">>,
@@ -2865,7 +2864,7 @@ make_and_wrap_sub_xform(Options, Node, Subscriber, SubId) ->
                                 | node_attr(Node)],
                        children = [XForm]},
     PubSubEl = #xmlel{name = <<"pubsub">>,
-                      attrs = [{<<"xmlns">>, ?NS_PUBSUB}], 
+                      attrs = [{<<"xmlns">>, ?NS_PUBSUB}],
                       children = [OptionsEl]},
     {result, PubSubEl}.
 
@@ -3865,7 +3864,7 @@ set_configure_valid_transaction(Host, #pubsub_node{ type = Type, options = Optio
         NewOpts when is_list(NewOpts) ->
             NewNode = NodeRec#pubsub_node{options = NewOpts},
             case tree_call(Host, set_node, [NewNode]) of
-                ok -> {result, NewNode};
+                {ok, _} -> {result, NewNode};
                 Err -> Err
             end;
         Error ->

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -68,7 +68,7 @@
 -callback del_node(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback set_node(Node :: mod_pubsub:pubsubNode()) -> ok.
+-callback set_node(Node :: mod_pubsub:pubsubNode()) -> {ok, mod_pubsub:nodeIdx()}.
 
 -callback find_node_by_id(Nidx :: mod_pubsub:nodeIdx()) ->
     {error, not_found} | {ok, mod_pubsub:pubsubNode()}.
@@ -79,7 +79,7 @@
 -callback find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
     [mod_pubsub:pubsubNode()].
 
--callback delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
+-callback delete_node(Node :: mod_pubsub:pubsubNode()) -> ok.
 
 -callback get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->
     [mod_pubsub:pubsubNode()].
@@ -162,7 +162,7 @@
     ok.
 
 -callback get_items(Nidx :: mod_pubsub:nodeIdx(), gen_pubsub_node:get_item_options()) ->
-    {ok, {[mod_pubsub:pubsubItem()], jlib:rsm_out()}}.
+    {ok, {[mod_pubsub:pubsubItem()], jlib:rsm_out() | none}}.
 
 -callback get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
     {ok, mod_pubsub:pubsubItem()} | {error, item_not_found}.

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -8,6 +8,8 @@
 -module(mod_pubsub_db_mnesia).
 -author('piotr.nosek@erlang-solutions.com').
 
+-behaviour(mod_pubsub_db).
+
 -include("pubsub.hrl").
 -include("jlib.hrl").
 -include_lib("stdlib/include/qlc.hrl").
@@ -26,7 +28,7 @@
          find_node_by_id/1,
          find_nodes_by_key/1,
          find_node_by_name/2,
-         delete_node/2,
+         delete_node/1,
          get_subnodes/2,
          get_parentnodes_tree/2,
          get_subnodes_tree/2
@@ -98,6 +100,7 @@ start() ->
                          {attributes, record_info(fields, pubsub_subscription)},
                          {type, set}]),
     mnesia:add_table_copy(pubsub_subscription, node(), disc_copies),
+    pubsub_index:init(),
     ok.
 
 -spec stop() -> ok.
@@ -209,9 +212,13 @@ del_node(Nidx) ->
                   end, States),
     {ok, States}.
 
--spec set_node(mod_pubsub:pubsubNode()) -> ok.
-set_node(Node) when is_record(Node, pubsub_node) ->
-    mnesia:write(Node).
+-spec set_node(mod_pubsub:pubsubNode()) -> {ok, mod_pubsub:nodeIdx()}.
+set_node(#pubsub_node{id = undefined} = Node) ->
+    CreateNode = Node#pubsub_node{id = pubsub_index:new(node)},
+    set_node(CreateNode);
+set_node(#pubsub_node{id = Nidx} = Node) ->
+    mnesia:write(Node),
+    {ok, Nidx}.
 
 
 -spec find_node_by_id(Nidx :: mod_pubsub:nodeIdx()) ->
@@ -252,9 +259,9 @@ find_nodes_by_id_and_pred(Key, Nodes, Pred) ->
 oid(Key, Name) -> {Key, Name}.
 
 
--spec delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
-delete_node(Key, Node) ->
-    mnesia:delete({pubsub_node, oid(Key, Node)}).
+-spec delete_node(Node :: mod_pubsub:pubsubNode()) -> ok.
+delete_node(#pubsub_node{nodeid = NodeId}) ->
+    mnesia:delete({pubsub_node, NodeId}).
 
 
 -spec get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->
@@ -361,7 +368,9 @@ get_node_subscriptions(Nidx) ->
 
 -spec get_node_entity_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
                                     LJID :: jid:ljid()) ->
-    {ok, [{Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+    {ok, [{Sub :: mod_pubsub:subscription(),
+           SubId :: mod_pubsub:subId(),
+           Opts :: mod_pubsub:subOptions()}]}.
 get_node_entity_subscriptions(Nidx, LJID) ->
     {ok, State} = get_state(Nidx, LJID, read),
     {ok, add_opts_to_subs(State#pubsub_state.subscriptions)}.
@@ -465,7 +474,7 @@ get_item(Nidx, ItemId) ->
         _ -> {error, item_not_found}
     end.
 
--spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok | abort.
+-spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok.
 set_item(Item) ->
     mnesia:write(Item).
 

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -9,6 +9,8 @@
 -author('piotr.nosek@erlang-solutions.com').
 -author('michal.piotrowski@erlang-solutions.com').
 
+-behaviour(mod_pubsub_db).
+
 -include("pubsub.hrl").
 -include("mongoose_logger.hrl").
 -include("jlib.hrl").
@@ -28,7 +30,7 @@
          find_node_by_id/1,
          find_nodes_by_key/1,
          find_node_by_name/2,
-         delete_node/2,
+         delete_node/1,
          get_subnodes/2,
          get_parentnodes_tree/2,
          get_subnodes_tree/2
@@ -183,7 +185,7 @@ get_item(Nidx, ItemId) ->
             {ok, item_to_record(Item)}
     end.
 
--spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok | abort.
+-spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok.
 set_item(#pubsub_item{itemid = {ItemId, NodeIdx},
                       creation = {CreatedAt, {CreatedLUser, CreatedLServer, _}},
                       modification = {ModifiedAt, {ModifiedLUser, ModifiedLServer, ModifiedLResource}},
@@ -228,7 +230,10 @@ del_node(Nidx) ->
     {updated, _} = mongoose_rdbms:sql_query(global, DelAllAffsQ),
     {ok, States}.
 
--spec set_node(Node :: mod_pubsub:pubsubNode()) -> ok.
+-spec set_node(Node :: mod_pubsub:pubsubNode()) -> {ok, mod_pubsub:nodeIdx()}.
+set_node(#pubsub_node{id = undefined} = Node) ->
+    CreateNode = Node#pubsub_node{id = pubsub_index:new(node)},
+    set_node(CreateNode);
 set_node(#pubsub_node{nodeid = {Key, Name}, id = Nidx, type = Type,
                       owners = Owners, options = Opts, parents = Parents}) ->
     OwnersJid = [jid:to_binary(Owner) || Owner <- Owners],
@@ -237,7 +242,7 @@ set_node(#pubsub_node{nodeid = {Key, Name}, id = Nidx, type = Type,
                                                      jsx:encode(Opts)),
     {updated, _} = mongoose_rdbms:sql_query(global, SQL),
     maybe_set_parents(Name, Parents),
-    ok.
+    {ok, Nidx}.
 
 maybe_set_parents(_Name, []) ->
     ok;
@@ -304,8 +309,8 @@ find_nodes_by_key(Key) ->
     [decode_pubsub_node_row(Row) || Row <- Rows].
 
 
--spec delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
-delete_node(Key, Node) ->
+-spec delete_node(Node :: mod_pubsub:pubsubNode()) -> ok.
+delete_node(#pubsub_node{nodeid = {Key, Node}}) ->
     SQL = mod_pubsub_db_rdbms_sql:delete_node(encode_key(Key), Node),
     {updated, _} = mongoose_rdbms:sql_query(global, SQL),
     ok.

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -91,13 +91,11 @@ create_node(Host, NodeName, Type, Owner, Options, Parents) ->
         false ->
             case check_parent_and_its_owner_list(Host, Parents, BJID) of
                 true ->
-                    Nidx = pubsub_index:new(node),
                     Node = #pubsub_node{nodeid = {Host, NodeName},
-                                        id = Nidx, parents = Parents,
+                                        parents = Parents,
                                         type = Type, owners = [BJID],
                                         options = Options},
-                    set_node(Node),
-                    {ok, Nidx};
+                    set_node(Node);
                 false ->
                     {error, mongoose_xmpp_errors:forbidden()}
             end;
@@ -126,9 +124,8 @@ check_parent_and_its_owner_list(_Host, _Parents, _BJID) ->
 delete_node(Host, Node) ->
     SubNodesTree = mod_pubsub_db_backend:get_subnodes_tree(Host, Node),
     Removed = lists:flatten([Nodes || {_, Nodes} <- SubNodesTree]),
-    lists:foreach(fun (#pubsub_node{nodeid = {_, SubNode}, id = SubNidx}) ->
-                pubsub_index:free(node, SubNidx),
-                mod_pubsub_db_backend:delete_node(Host, SubNode)
+    lists:foreach(fun (NodeToDel) ->
+                mod_pubsub_db_backend:delete_node(NodeToDel)
         end,
         Removed),
     Removed.

--- a/src/pubsub/pubsub_index.erl
+++ b/src/pubsub/pubsub_index.erl
@@ -4,13 +4,13 @@
 %%% compliance with the License. You should have received a copy of the
 %%% Erlang Public License along with this software. If not, it can be
 %%% retrieved via the world wide web at http://www.erlang.org/.
-%%% 
+%%%
 %%%
 %%% Software distributed under the License is distributed on an "AS IS"
 %%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
 %%% the License for the specific language governing rights and limitations
 %%% under the License.
-%%% 
+%%%
 %%%
 %%% The Initial Developer of the Original Code is ProcessOne.
 %%% Portions created by ProcessOne are Copyright 2006-2015, ProcessOne
@@ -33,9 +33,9 @@
 
 -include("pubsub.hrl").
 
--export([init/3, new/1, free/2]).
+-export([init/0, new/1]).
 
-init(_Host, _ServerHost, _Opts) ->
+init() ->
     mnesia:create_table(pubsub_index,
                         [{disc_copies, [node()]},
                          {attributes, record_info(fields, pubsub_index)}]).
@@ -43,24 +43,11 @@ init(_Host, _ServerHost, _Opts) ->
 new(Index) ->
     case mnesia:read({pubsub_index, Index}) of
         [I] ->
-            case I#pubsub_index.free of
-                [] ->
-                    Id = I#pubsub_index.last + 1,
-                    mnesia:write(I#pubsub_index{last = Id}),
-                    Id;
-                [Id | Free] ->
-                    mnesia:write(I#pubsub_index{free = Free}), Id
-            end;
+            Id = I#pubsub_index.last + 1,
+            mnesia:write(I#pubsub_index{last = Id}),
+            Id;
         _ ->
             mnesia:write(#pubsub_index{index = Index, last = 1, free = []}),
             1
     end.
 
-free(Index, Id) ->
-    case mnesia:read({pubsub_index, Index}) of
-        [I] ->
-            Free = I#pubsub_index.free,
-            mnesia:write(I#pubsub_index{free = [Id | Free]});
-        _ ->
-            ok
-    end.

--- a/test/gen_mod_SUITE.erl
+++ b/test/gen_mod_SUITE.erl
@@ -51,8 +51,8 @@ start_and_stop(_Config) ->
     {ok, _} = gen_mod:start_module(host(b), a_module, []),
     {error, already_started} = gen_mod:start_module(host(a), a_module, []),
     {error, already_started} = gen_mod:start_module(host(b), a_module, []),
-    ok = gen_mod:stop_module(host(a), a_module),
-    ok = gen_mod:stop_module(host(b), a_module),
+    {ok, []} = gen_mod:stop_module(host(a), a_module),
+    {ok, []} = gen_mod:stop_module(host(b), a_module),
     {error, not_loaded} = gen_mod:stop_module(host(a), a_module),
     {error, not_loaded} = gen_mod:stop_module(host(b), a_module),
     ok.


### PR DESCRIPTION
Before only function execution time was measured,
there was no information about number of given function calls
which is often as important as the execution time.
